### PR TITLE
Improve quests persistence and weekly challenge

### DIFF
--- a/client/src/components/ConfettiAnimation.js
+++ b/client/src/components/ConfettiAnimation.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import Confetti from 'react-dom-confetti';
 
 const ConfettiConfig = {
@@ -8,22 +9,36 @@ const ConfettiConfig = {
   dragFriction: 0.12,
   duration: 3000,
   stagger: 3,
-  width: "10px",
-  height: "10px",
-  perspective: "500px",
-  colors: ["#a864fd", "#29cdff", "#78ff44", "#ff718d", "#fdff6a"]
+  width: '10px',
+  height: '10px',
+  perspective: '500px',
+  colors: ['#a864fd', '#29cdff', '#78ff44', '#ff718d', '#fdff6a'],
 };
 
-const ConfettiAnimation = ({ allTasksDone }) => (
-  <div style={{
-    position: 'fixed', 
-    top: 0, 
-    left: '50%', 
-    transform: 'translateX(-50%)',
-    zIndex: 1000
-  }}>
-    <Confetti active={ allTasksDone } config={ ConfettiConfig } />
-  </div>
-);
+const ConfettiAnimation = ({ allTasksDone }) => {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (allTasksDone) {
+      setActive(true);
+      const timer = setTimeout(() => setActive(false), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [allTasksDone]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 1000,
+      }}
+    >
+      <Confetti active={active} config={ConfettiConfig} />
+    </div>
+  );
+};
 
 export default ConfettiAnimation;

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { getZenQuote } from '../api/quoteApi';
 import TaskList from './TaskList';
+import WeeklyQuest from './WeeklyQuest';
 import { fetchHealthResources } from '../api/HealthApi';
 import HealthResourceList from './healthResourceList';
 import MeshGradient from 'mesh-gradient.js';
@@ -104,6 +105,7 @@ export const Home = () => {
                 <p className="text-xl lg:text-2xl text-center justify-center bg-gradient-to-l from-emerald-600 via-emerald-500 to-emerald-600 bg-clip-text text-transparent font-nexa font-bold">Daily Quests:</p>
 
                 <TaskList />
+                <WeeklyQuest />
               </div>
               <div className=" w-full p-4 lg:p-8 bg-opacity-80  bg-white rounded-lg shadow">
                 <p className="text-xl lg:text-2xl text-center bg-gradient-to-l from-emerald-600 via-emerald-500 to-emerald-600 bg-clip-text text-transparent font-nexa font-bold">Today's Inspiring Quote:</p>

--- a/client/src/components/TaskList.js
+++ b/client/src/components/TaskList.js
@@ -16,20 +16,22 @@ const TaskList = () => {
     let randomTasks;
 
     if (storedDate === today) {
-      // If the tasks for the current date have already been stored, use them
+      // Use stored tasks for today
       randomTasks = JSON.parse(localStorage.getItem('tasks'));
+      const storedCheckedTasks = JSON.parse(localStorage.getItem('checkedTasks')) || [];
+      setCheckedTasks(storedCheckedTasks.length ? storedCheckedTasks : new Array(randomTasks.length).fill(false));
     } else if (data?.tasks) {
-      // If there are no tasks for the current date, generate and store new tasks
+      // Generate new tasks for a new day
       randomTasks = random(data.tasks).slice(0, 4);
       localStorage.setItem('tasks', JSON.stringify(randomTasks));
       localStorage.setItem('tasksDate', today);
+      const defaultCheckedTasks = new Array(randomTasks.length).fill(false);
+      localStorage.setItem('checkedTasks', JSON.stringify(defaultCheckedTasks));
+      setCheckedTasks(defaultCheckedTasks);
     }
 
     if (randomTasks) {
       setTasks(randomTasks);
-      // Load the checked state from localStorage, or initialize with false if not present
-      const storedCheckedTasks = JSON.parse(localStorage.getItem('checkedTasks')) || new Array(randomTasks.length).fill(false);
-      setCheckedTasks(storedCheckedTasks);
     }
   }, [data]);
 

--- a/client/src/components/WeeklyQuest.js
+++ b/client/src/components/WeeklyQuest.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { GET_TASKS } from '../utils/queries';
+import { random } from '../utils/randomizer';
+
+function getWeekKey(date = new Date()) {
+  const firstDay = new Date(date.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((date - firstDay) / 86400000);
+  return `${date.getFullYear()}-W${Math.ceil((dayOfYear + firstDay.getDay() + 1) / 7)}`;
+}
+
+const WeeklyQuest = () => {
+  const { data } = useQuery(GET_TASKS);
+  const [quest, setQuest] = useState('');
+
+  useEffect(() => {
+    const currentWeek = getWeekKey();
+    const storedWeek = localStorage.getItem('weeklyQuestWeek');
+    let q;
+    if (storedWeek === currentWeek) {
+      q = localStorage.getItem('weeklyQuest');
+    } else if (data?.tasks) {
+      q = random(data.tasks)[0].task;
+      localStorage.setItem('weeklyQuest', q);
+      localStorage.setItem('weeklyQuestWeek', currentWeek);
+    }
+    if (q) {
+      setQuest(q);
+    }
+  }, [data]);
+
+  return (
+    <div className="bg-white bg-opacity-80 p-4 rounded-lg shadow mt-4 text-center">
+      <p className="font-nexa font-bold text-emerald-500">Weekly Quest:</p>
+      <p className="mt-2">{quest}</p>
+    </div>
+  );
+};
+
+export default WeeklyQuest;


### PR DESCRIPTION
## Summary
- trigger confetti when tasks complete
- persist checked tasks per day
- show weekly quest

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408a3dd9848324a681efd22852f6cd